### PR TITLE
[ADMINAPI-66] - GitHub Action workflow for Release

### DIFF
--- a/.github/workflows/release-security-data-access-compatibility-53.yml
+++ b/.github/workflows/release-security-data-access-compatibility-53.yml
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Release EdFi.Security.DataAccess Compatibility 5.3
+on: workflow_dispatch
+env:
+  ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  ARTIFACTS_FEED_URL: ${{ secrets.AZURE_ARTIFACTS_FEED_URL }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint": "${{ secrets.AZURE_ARTIFACTS_FEED_URL }}","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  MANIFEST_FILE: "_manifest/spdx_2.2/manifest.spdx.json"
+  PACKAGE_NAME: "Security.DataAccess"
+jobs:
+  pack:
+    name: Build and Pack
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    outputs:
+      hash-code: ${{ steps.hash-code.outputs.hash-code }}
+      security-data-access-version: 5.3.43
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2.0.0
+        with:
+          dotnet-version: 2.1.x
+
+      - name: Build
+        run: dotnet build --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release
+
+      - name: Create NuGet Packages
+        if: success()
+        run: |
+          "Packing ${{ env.PACKAGE_NAME }} NuGet Package" | Write-Output
+          dotnet pack --output . --configuration Release
+
+      - name: Generate hash for NuGet package
+        id: hash-code
+        shell: bash
+        run: |
+          echo "::set-output name=hash-code::$(sha256sum *.nupkg | base64 -w0)"
+
+      - name: Upload Packages as Artifacts
+        if: success()
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: "${{ env.PACKAGE_NAME }}-NuGet"
+          path: ./*.nupkg
+          if-no-files-found: error
+          retention-days: 30
+
+  sbom-create:
+    name: Create SBOM
+    runs-on: ubuntu-latest
+    needs: pack
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      sbom-hash-code: ${{ steps.sbom-hash-code.outputs.sbom-hash-code }}
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: Get Artifacts
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 #v3.0.0
+        with:
+          name: ${{ env.PACKAGE_NAME }}-NuGet
+
+      - name: Generate Software Bill of Materials (SBOM) - API
+        shell: pwsh
+        run: |
+          $packageName = "${{ env.PACKAGE_NAME }}"
+
+          $url = "https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64"
+          $out = "$($env:RUNNER_TEMP)/sbom-tool"
+          Invoke-RestMethod -Uri $url -OutFile $out
+          chmod +x $out
+
+          Get-ChildItem -Include "EdFi.Suite3.$packageName.*.nupkg" -Recurse | ForEach-Object { $_.FullName } > buildfilelist.txt
+          New-Item -Path manifest -Type Directory
+
+          $version = "${{ needs.pack.outputs.security-data-access-version }}"
+
+          &$out generate `
+              -b ./ `
+              -bl ./buildfilelist.txt `
+              -bc "./Application/EdFi.$packageName" `
+              -pn "EdFi.Suite3.$packageName" `
+              -pv $version `
+              -nsb https://ed-fi.org `
+              -m manifest `
+              -ps "Ed-Fi Alliance"
+
+      - name: Upload SBOM
+        if: success()
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: ${{ env.PACKAGE_NAME }}-SBOM
+          path: ./manifest
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Generate hash code for SBOM
+        id: sbom-hash-code
+        shell: bash
+        run: |
+          # sha256sum returns "<hashcode>  <name of file". Split that and return only the <hashcode>.
+          sbom_hash=$(sha256sum ./manifest/${{ env.MANIFEST_FILE }} | awk '{split($0,a); print a[1]}')
+          echo "::set-output name=sbom-hash-code::$sbom_hash"
+
+  sbom-attach:
+    name: Attach SBOM file
+    runs-on: ubuntu-latest
+    needs:
+      - sbom-create
+      - pack
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download the SBOM
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1d646d70aeba1516af69fb0ef48206580122449b
+        with:
+          name: "${{ env.PACKAGE_NAME }}-SBOM"
+          path: ${{ env.MANIFEST_FILE }}
+          sha256: "${{ needs.sbom-create.outputs.sbom-hash-code }}"
+
+      - name: Attach to release
+        shell: pwsh
+        run: |
+          $release = "${{ github.ref_name }}"
+          $repo = "${{ github.repository }}"
+          $token = "${{ secrets.GITHUB_TOKEN }}"
+          $file = "${{ env.MANIFEST_FILE }}"
+          $uploadName = "${{ env.PACKAGE_NAME }}-SBOM.zip"
+
+          $url = "https://api.github.com/repos/$repo/releases/tags/$release"
+
+          $gh_headers = @{
+              "Accept"        = "application/vnd.github+json"
+              "Authorization" = "Bearer $token"
+          }
+
+          $response = Invoke-RestMethod -Uri $url -Headers $gh_headers
+          $releaseId = $response.id
+
+          $url = "https://uploads.github.com/repos/$repo/releases/$releaseId/assets"
+
+          Compress-Archive $file -DestinationPath $uploadName
+
+          $gh_headers["Content-Type"] = "application/octet"
+          Invoke-RestMethod -Method POST `
+              -Uri "$($url)?name=$($uploadName)" `
+              -Headers $gh_headers `
+              -InFile $uploadName
+
+  provenance-create:
+    name: Create Provenance
+    needs: pack
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: ${{ needs.pack.outputs.hash-code }}
+      attestation-name: Security.DataAccess.intoto.jsonl
+      upload-assets: true
+      # TODO: remove this after this issue is resolved: https://github.com/slsa-framework/slsa-github-generator/issues/876
+      compile-generator: true
+
+  publish-package:
+    name: Publish NuGet Package
+    needs: pack
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: Get Artifact
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 #v3.0.0
+        with:
+          name: ${{ env.PACKAGE_NAME }}-NuGet
+
+      - name: Install-credential-handler
+        run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+
+      - name: Push Package to Azure Artifacts
+        run: |
+          $nuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
+          $nuGetFeed = "${{ env.ARTIFACTS_FEED_URL }}"
+          $artifact = (Get-ChildItem -Path $_ -Name -Include *.nupkg)
+
+          $artifact | ForEach-Object {
+              $packageFile = $_
+              Write-Host "Pushing $packageFile to $nuGetFeed"
+              dotnet nuget push $packageFile --api-key $nuGetApiKey --source $nuGetFeed
+           }

--- a/.github/workflows/release-security-data-access-compatibility-53.yml
+++ b/.github/workflows/release-security-data-access-compatibility-53.yml
@@ -27,13 +27,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2.0.0
         with:
-          dotnet-version: 2.1.x
+          dotnet-version: 6.0.x
 
       - name: Build
         run: dotnet build --configuration Release
+
+      - name: Setup .NET Core 3.1
+        uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2.0.0
+        with:
+          dotnet-version: 3.1.x
 
       - name: Test
         run: dotnet test --no-build --configuration Release

--- a/.github/workflows/release-security-data-access-compatibility-53.yml
+++ b/.github/workflows/release-security-data-access-compatibility-53.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
+        working-directory: ./NuGet/EdFi.Security.DataAccess/53/
         shell: pwsh
     outputs:
       hash-code: ${{ steps.hash-code.outputs.hash-code }}
@@ -60,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: "${{ env.PACKAGE_NAME }}-NuGet"
-          path: ./*.nupkg
+          path: ./NuGet/EdFi.Security.DataAccess/53/*.nupkg 
           if-no-files-found: error
           retention-days: 30
 
@@ -99,7 +100,7 @@ jobs:
           &$out generate `
               -b ./ `
               -bl ./buildfilelist.txt `
-              -bc "./Application/EdFi.$packageName" `
+              -bc "./NuGet/EdFi.$packageName" `
               -pn "EdFi.Suite3.$packageName" `
               -pv $version `
               -nsb https://ed-fi.org `

--- a/.github/workflows/release-security-data-access-compatibility-53.yml
+++ b/.github/workflows/release-security-data-access-compatibility-53.yml
@@ -54,7 +54,7 @@ jobs:
         id: hash-code
         shell: bash
         run: |
-          echo "::set-output name=hash-code::$(sha256sum *.nupkg | base64 -w0)"
+          echo "hash-code=$(sha256sum *.nupkg | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: Upload Packages as Artifacts
         if: success()
@@ -122,7 +122,7 @@ jobs:
         run: |
           # sha256sum returns "<hashcode>  <name of file". Split that and return only the <hashcode>.
           sbom_hash=$(sha256sum ./manifest/${{ env.MANIFEST_FILE }} | awk '{split($0,a); print a[1]}')
-          echo "::set-output name=sbom-hash-code::$sbom_hash"
+          echo "sbom-hash-code=$sbom_hash" >> $GITHUB_OUTPUT
 
   sbom-attach:
     name: Attach SBOM file

--- a/NuGet/EdFi.Security.DataAccess/53/Directory.Build.props
+++ b/NuGet/EdFi.Security.DataAccess/53/Directory.Build.props
@@ -1,0 +1,7 @@
+﻿<Project>
+    <PropertyGroup>
+        <Version>5.3.43</Version>
+        <FileVersion>5.3.43</FileVersion>
+        <InformationalVersion>5.3</InformationalVersion>
+    </PropertyGroup>
+</Project>

--- a/NuGet/EdFi.Security.DataAccess/53/NuGet.Config
+++ b/NuGet/EdFi.Security.DataAccess/53/NuGet.Config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <packageSources>
+    <add key="Ed-Fi Alliance NuGet Feed" value="https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
**Description**
* Added `Directory.Build.props` hardcoded to the `5.3.43` version.
* Added `release-security-data-access-compatibility-53.yml` workflow to manually release the `EdFi.SecurityCompatibility53.DataAccess` package.
* Added `NuGet.Config`.

**NOTE:** 
- The workflow was tested (except the push package step) [on a fork](https://github.com/saa14/Ed-Fi-Compatibility-Libraries/actions/runs/3698268877)
- The `env variables` for Ed-Fi NuGet Feed need to be set up before triggering the workflow